### PR TITLE
ES2015 import support

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2285,3 +2285,5 @@
     return getnlp._nlp
   }
 })); // eslint-disable-line
+
+export default RRule;


### PR DESCRIPTION
This fixed the ability to import rrule to the window object when using webpack v2.2.x.